### PR TITLE
use api version 4.0.0, update gradle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+#
+# https://help.github.com/articles/dealing-with-line-endings/
+#
+# These are explicitly windows files and should use crlf
+*.bat           text eol=crlf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: |
-            17
-            8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: init submodule
         run: git submodule init && git submodule update
       - name: Build with Gradle
-        run: ./gradlew build -Dorg.gradle.java.home="$JAVA_HOME_17_X64"
+        run: ./gradlew shadowJar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: |
-            8
-            17
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: init submodule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Allow sharing of crash reports
+- Makes use of API version 4.0.0, allowing for marginal performance increases as API calls are now Async

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'fabric-loom' version '1.0-SNAPSHOT'
+	id 'fabric-loom' version '1.2.7'
 	id "com.modrinth.minotaur" version "2.8.1"
 	id "net.darkhax.curseforgegradle" version "1.1.15"
 	id 'com.github.johnrengelman.shadow' version '8.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 plugins {
 	id 'java'
 	id 'fabric-loom' version '1.0-SNAPSHOT'
-	id "com.modrinth.minotaur" version "2.+"
-	id "net.darkhax.curseforgegradle" version "1.0.11"
+	id "com.modrinth.minotaur" version "2.8.1"
+	id "net.darkhax.curseforgegradle" version "1.1.15"
+	id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 archivesBaseName = project.archives_base_name
 version = project.hasProperty('release') ? project.getProperty('release') : 'dev'
@@ -16,7 +17,6 @@ changelog = rootProject.file("CHANGELOG.md").text
 dependencies {
 	// Mclogs Java - Library to read, list and share logs to mclogs
 	implementation project(path: ":mclogs-java", configuration: 'default')
-	include project(path: ":mclogs-java", configuration: 'default')
 
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -81,7 +81,7 @@ task publishCurseforge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge)
 	mainFile.addModLoader("Quilt")
 	mainFile.addRequirement("fabric-api")
 	mainFile.addRequirement("qsl")
-	mainFile.addJavaVersion("Java ${JavaVersion.current().majorVersion}")
+	mainFile.addJavaVersion("Java 11")
 	mainFile.addGameVersion("1.16.5")
 	mainFile.addGameVersion("1.16.4")
 	mainFile.addGameVersion("1.16.3")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/gs/mclo/fabric/MclogsFabricLoader.java
+++ b/src/main/java/gs/mclo/fabric/MclogsFabricLoader.java
@@ -1,9 +1,9 @@
 package gs.mclo.fabric;
 
 import com.mojang.brigadier.context.CommandContext;
-import gs.mclo.java.APIResponse;
-import gs.mclo.java.Log;
-import gs.mclo.java.MclogsAPI;
+import gs.mclo.api.Log;
+import gs.mclo.api.MclogsClient;
+import gs.mclo.api.response.UploadLogResponse;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
@@ -21,9 +21,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 public class MclogsFabricLoader implements DedicatedServerModInitializer {
     public static final Logger logger = LogManager.getLogger();
+    private static final MclogsClient client = new MclogsClient("Mclogs-fabric");
 
     /**
      * @param context command context
@@ -31,7 +34,7 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
      * @throws IOException io exception
      */
     public static String[] getLogs(CommandContext<ServerCommandSource> context) throws IOException {
-        return MclogsAPI.listLogs(context.getSource().getMinecraftServer().getRunDirectory().getCanonicalPath());
+        return client.listLogsInDirectory(context.getSource().getMinecraftServer().getRunDirectory().getCanonicalPath());
     }
 
     /**
@@ -40,11 +43,11 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
      * @throws IOException io exception
      */
     public static String[] getCrashReports(CommandContext<ServerCommandSource> context) throws IOException {
-        return MclogsAPI.listCrashReports(context.getSource().getMinecraftServer().getRunDirectory().getCanonicalPath());
+        return client.listCrashReportsInDirectory(context.getSource().getMinecraftServer().getRunDirectory().getCanonicalPath());
     }
 
     public static int share(ServerCommandSource source, String filename) {
-        MclogsAPI.mcversion = source.getMinecraftServer().getVersion();
+        client.setMinecraftVersion(source.getMinecraftServer().getVersion());
         logger.log(Level.INFO,"Sharing "+filename);
         source.sendFeedback(new LiteralText("Sharing " + filename), false);
 
@@ -73,14 +76,16 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
         }
 
         try {
-            APIResponse response = MclogsAPI.share(log);
-            if (response.success) {
+            CompletableFuture<UploadLogResponse> response = client.uploadLog(log);
+            UploadLogResponse res = response.get();
+            res.setClient(client);
+            if (res.isSuccess()) {
                 LiteralText feedback = new LiteralText("Your log has been uploaded: ");
                 feedback.setStyle(Style.EMPTY.withColor(Formatting.GREEN));
 
-                LiteralText link = new LiteralText(response.url);
+                LiteralText link = new LiteralText(res.getUrl());
                 Style linkStyle = Style.EMPTY.withColor(Formatting.BLUE);
-                linkStyle = linkStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL,response.url));
+                linkStyle = linkStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL,res.getUrl()));
                 link.setStyle(linkStyle);
 
                 source.sendFeedback(feedback.append(link),true);
@@ -88,7 +93,7 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
             }
             else {
                 logger.error("An error occurred when uploading your log: ");
-                logger.error(response.error);
+                logger.error(res.getError());
                 LiteralText error = new LiteralText("An error occurred. Check your log for more details");
                 source.sendError(error);
                 return 0;
@@ -99,7 +104,7 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
             source.sendError(error);
             return -1;
         }
-        catch (IOException e) {
+        catch (IOException | InterruptedException | ExecutionException e) {
             source.sendError(new LiteralText("An error occurred. Check your log for more details"));
             logger.error("Could not get log file!");
             logger.error(e);
@@ -109,10 +114,8 @@ public class MclogsFabricLoader implements DedicatedServerModInitializer {
 
     @Override
     public void onInitializeServer() {
-        MclogsAPI.userAgent = "Mclogs-fabric";
         Optional<ModContainer> mclogs = FabricLoader.getInstance().getModContainer("mclogs");
-        MclogsAPI.version = mclogs.isPresent() ? mclogs.get().getMetadata().getVersion().getFriendlyString() : "unknown";
-
+        client.setProjectVersion(mclogs.isPresent() ? mclogs.get().getMetadata().getVersion().getFriendlyString() : "unknown");
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
             CommandMclogs.register(dispatcher);
             CommandMclogsList.register(dispatcher);


### PR DESCRIPTION
- Updates all gradle plugins 
- Updates gradle wrapper to 8.1.1
- Uses api version 4.0.0 
- Specifies Java 11 
- Updates git workflow versions, use gradle wrapper validation 

A couple things on your end 
- Probably want to update minecraft versions 
- Releasing will have to be altered with the shadow update, likely just to fix naming conventions. This will also require updating the release workflow
- You said on API that you wanted to maintain java 8 compat, but most updated fabric strict checks for j17, which causes build fails
- Minecraft version is not passing properly, but I'm too unfamiliar with Fabric and stackoverflow is down :( 

Note this is very minimally tested
